### PR TITLE
Add url text field

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -52,7 +52,7 @@ __all__ = [str(x) for x in (
     'GenericIPAddressField', 'IPAddressField', 'IntegerField', 'NOT_PROVIDED',
     'NullBooleanField', 'PositiveIntegerField', 'PositiveSmallIntegerField',
     'SlugField', 'SmallIntegerField', 'TextField', 'TimeField', 'URLField',
-    'UUIDField',
+    'URLTextField', 'UUIDField',
 )]
 
 
@@ -2333,6 +2333,11 @@ class URLField(CharField):
         }
         defaults.update(kwargs)
         return super(URLField, self).formfield(**defaults)
+
+
+class URLTextField(TextField):
+    default_validators = [validators.URLValidator()]
+    description = _("URLText")
 
 
 class BinaryField(Field):

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1076,6 +1076,19 @@ Like all :class:`CharField` subclasses, :class:`URLField` takes the optional
 :attr:`~CharField.max_length` argument. If you don't specify
 :attr:`~CharField.max_length`, a default of 200 is used.
 
+``URLTextField``
+------------
+
+.. class:: URLTextField(**options)
+
+A :class:`TextField` for a URL longer than the limit of `CharField`.
+
+The default form widget for this field is a :class:`~django.forms.TextArea`.
+
+Like all :class:`TextField` subclasses, :class:`URLTextField` takes the optional
+:attr:`~TextField.max_length` argument. Please refer `~TextField` docuemnt for
+detail.
+
 ``UUIDField``
 -------------
 

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -185,6 +185,7 @@ class VerboseNameField(models.Model):
     field21 = models.URLField("verbose field21")
     field22 = models.UUIDField("verbose field22")
     field23 = models.DurationField("verbose field23")
+    field24 = models.URLTextField("verbose field24")
 
 
 class GenericIPAddress(models.Model):
@@ -340,6 +341,7 @@ class AllFieldsModel(models.Model):
     time = models.TimeField()
     url = models.URLField()
     uuid = models.UUIDField()
+    url_text = models.URLTextField()
 
     fo = ForeignObject(
         'self',

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -16,7 +16,7 @@ from django.db.models.fields import (
     DecimalField, EmailField, FilePathField, FloatField, GenericIPAddressField,
     IntegerField, IPAddressField, NullBooleanField, PositiveIntegerField,
     PositiveSmallIntegerField, SlugField, SmallIntegerField, TextField,
-    TimeField, URLField,
+    TimeField, URLField, URLTextField,
 )
 from django.db.models.fields.files import FileField, ImageField
 from django.test.utils import requires_tz_support
@@ -981,6 +981,12 @@ class PromiseTest(test.SimpleTestCase):
         lazy_func = lazy(lambda: 'http://domain.com', six.text_type)
         self.assertIsInstance(
             URLField().get_prep_value(lazy_func()),
+            six.text_type)
+
+    def test_URLTextField(self):
+        lazy_func = lazy(lambda: 'http://domain.com', six.text_type)
+        self.assertIsInstance(
+            URLTextField().get_prep_value(lazy_func()),
             six.text_type)
 
 

--- a/tests/model_forms/models.py
+++ b/tests/model_forms/models.py
@@ -227,6 +227,10 @@ class Homepage(models.Model):
     url = models.URLField()
 
 
+class Webpage(models.Model):
+    url = models.URLTextField()
+
+
 @python_2_unicode_compatible
 class Product(models.Model):
     slug = models.SlugField(unique=True)

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -29,7 +29,7 @@ from .models import (
     DerivedBook, DerivedPost, Document, ExplicitPK, FilePathModel,
     FlexibleDatePost, Homepage, ImprovedArticle, ImprovedArticleWithParentLink,
     Inventory, Person, Photo, Post, Price, Product, Publication,
-    PublicationDefaults, Student, StumpJoke, TextFile, Triple, Writer,
+    PublicationDefaults, Student, StumpJoke, TextFile, Triple, Webpage, Writer,
     WriterProfile, test_images,
 )
 
@@ -2196,6 +2196,28 @@ class ModelOtherFieldTests(SimpleTestCase):
         form = HomepageForm({'url': 'example.com/test'})
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data['url'], 'http://example.com/test')
+
+    def test_url_text_on_modelform(self):
+        "Check basic URL field validation on model forms"
+        class WebpageForm(forms.ModelForm):
+            class Meta:
+                model = Webpage
+                fields = '__all__'
+
+        self.assertFalse(WebpageForm({'url': 'foo'}).is_valid())
+        self.assertFalse(WebpageForm({'url': 'http://'}).is_valid())
+        self.assertFalse(WebpageForm({'url': 'http://example'}).is_valid())
+        self.assertFalse(WebpageForm({'url': 'http://example.'}).is_valid())
+        self.assertFalse(WebpageForm({'url': 'http://com.'}).is_valid())
+
+        self.assertTrue(WebpageForm({'url': 'http://localhost'}).is_valid())
+        self.assertTrue(WebpageForm({'url': 'http://example.com'}).is_valid())
+        self.assertTrue(WebpageForm({'url': 'http://www.example.com'}).is_valid())
+        self.assertTrue(WebpageForm({'url': 'http://www.example.com:8000'}).is_valid())
+        self.assertTrue(WebpageForm({'url': 'http://www.example.com/test'}).is_valid())
+        self.assertTrue(WebpageForm({'url': 'http://www.example.com:8000/test'}).is_valid())
+        self.assertTrue(WebpageForm({'url': 'http://example.com/foo/bar'}).is_valid())
+        self.assertTrue(WebpageForm({'url': 'http://example.com/foo/bar/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long/long'}).is_valid())
 
 
 class OtherModelFormTests(TestCase):


### PR DESCRIPTION
There exists [URLField](https://docs.djangoproject.com/en/1.8/ref/models/fields/#urlfield), but according to  [Character fields](https://docs.djangoproject.com/en/1.8/ref/databases/#character-fields) it is stored VARCHAR column types and max_length is limited to 255 characters if `unique=True`.
I would like to have long URLs with `unique=True`, so I created `URLTextField`.
